### PR TITLE
Fix callbacks for error and 403, message if no lyrics could be found

### DIFF
--- a/versuri.el
+++ b/versuri.el
@@ -321,9 +321,12 @@ the call with the remaining websites."
 									 ;; makeitpersonal
 									 (not (s-contains? "Sorry, We don't have lyrics" resp)))
 								;; Positive response
-								(when-let (lyrics (versuri--parse website resp))
-								  (versuri--db-save-lyrics artist song lyrics)
-								  (versuri-lyrics artist song callback))
+								(if-let (lyrics (versuri--parse website resp))
+									(progn
+									  (versuri--db-save-lyrics artist song lyrics)
+									  (versuri-lyrics artist song callback))
+								  ;; Lyrics not found, try another website.
+								  (versuri-lyrics artist song callback (-remove-item website websites)))
 							  ;; Lyrics not found, try another website.
 							  (versuri-lyrics artist song callback
 											  (-remove-item website websites)))))

--- a/versuri.el
+++ b/versuri.el
@@ -273,11 +273,7 @@ of an error."
                 (funcall callback data)))
     :error (lambda (&rest _)
              ;; Website does not have the lyrics for this song
-             (funcall callback nil))
-    :status-code
-    `((403 . ,(lambda (&rest _)
-				;; Nothing to do if you got banned.
-				(funcall callback nil)))))
+             (funcall callback nil)))
   nil)
 
 (defun versuri--parse (website html)


### PR DESCRIPTION
Hi, thanks for the great package!

I received errors on the callbacks in the request for errors and 403
because these callbacks were receiving a different amount of arguments than expected.
Additionally, I also experienced a "void-variable 'callback" for the 403 lambda.

This PR would fix this issue and as a (optional) bonus message the caller if no lyrics where found on any of the websites used for the search.