### PR TITLE
improve the lyrics buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ _musixmatch_, _azlyrics_.
 
 - Backed up with a local database.
 
-- Search through the database interactively with ivy.
+- Search through the database interactively.
 
 - Display lyrics in a text buffer or save them for later use.
 
@@ -51,20 +51,22 @@ Beware! This will block Emacs.
 ## Search artist and song from known lyrics
 
 Search for all lyrics in the database that match a given string and
-interactively select one of the entries with ivy. With a space before the
-string, select from all artists that matches the string. With an empty string,
-select from all the songs in the database.
+interactively select one of the entries with `completing-read`. With a
+space before the string, select from all artists that matches the
+string. With an empty string, select from all the songs in the
+database.
 
-For example, this will search for all songs that contain "tonight" in their lyrics. Further
-filtering available thanks to ivy.
+For example, this will search for all songs that contain "tonight" in
+their lyrics. Further filtering available thanks to a completion UI
+like ivy, icomplete, etc.
 
 ```emacs-lisp
-(versuri-ivy-search "tonight")
+(versuri-search "tonight")
 ```
 ![image](https://user-images.githubusercontent.com/8273519/73678593-595b2780-46c1-11ea-9370-c53a0bb1158c.png)
 
-`versuri-ivy-search` is interactive, so the search string can be given in the
-minibuffer as well.
+`versuri-search` is interactive, so the search string can be given in
+the minibuffer as well.
 
 ![image](https://user-images.githubusercontent.com/8273519/73678604-5f510880-46c1-11ea-95b0-df43d1f4fb66.png)
 
@@ -98,6 +100,10 @@ will be implemented.
 
 # Complete API
 
+**versuri-mode**
+
+    Major mode for versuri lyrics buffers.
+
 **versuri-display** (artist song)
 
     Search and display the lyrics for ARTIST and SONG in a buffer.
@@ -129,11 +135,12 @@ will be implemented.
 
     Remove entry for ARTIST and SONG form the database.
 
-**versuri-ivy-search** (str)
+**versuri-search** (str)
 
     Search the database for all entries that match STR.
-    Use ivy to let the user select one of the entries and return it.
-    Each entry contains the artist name, song name and a verse line.
+    Use completing-read to let the user select one of the entries
+    and return it.  Each entry contains the artist name, song name
+    and a verse line.
 
     If STR is empty, this is a search through all the entries in the
     database.

--- a/versuri.el
+++ b/versuri.el
@@ -331,6 +331,10 @@ the call with the remaining websites."
               (versuri-lyrics artist song callback
                               (-remove-item website websites))))))))
 
+(define-derived-mode versuri-mode fundamental-mode "versuri"
+  "Major mode for versuri lyrics buffers."
+  (read-only-mode))
+
 (defun versuri-display (artist song)
   "Search and display the lyrics for ARTIST and SONG in a buffer.
 
@@ -359,7 +363,7 @@ be ugly."
               (save-excursion
                 (insert (format "%s - %s\n\n" artist song))
                 (insert lyrics))
-              (read-only-mode)
+              (versuri-mode)
               (local-set-key (kbd "q") 'kill-current-buffer)
               ;; Forget about these lyrics.
               (local-set-key (kbd "x")

--- a/versuri.el
+++ b/versuri.el
@@ -356,8 +356,9 @@ be ugly."
             (switch-to-buffer it)
           (let ((b (generate-new-buffer name)))
             (with-current-buffer b
-              (insert (format "%s - %s\n\n" artist song))
-              (insert lyrics)
+              (save-excursion
+                (insert (format "%s - %s\n\n" artist song))
+                (insert lyrics))
               (read-only-mode)
               (local-set-key (kbd "q") 'kill-current-buffer)
               ;; Forget about these lyrics.


### PR DESCRIPTION
these are some tweaks to how the lyrics buffer is managed:

 - it'd be nice if the point was at the beginning of the buffer instead of at the end
 - defining a custom major mode for the lyrics lets user further customize the behavior of the buffer, be it with new keybindings (using `versuri-lyrics-mode-map`) or enabling other minor  modes in `versuri-lyrics-mode-hook`.  For instance, i like to bind `n` and `p` to next/previous line and enable `hl-line-mode`.
 - move the hard-coded keys to their own function and bind them by default in `versuri-lyrics-mode`: this helps with discoverability and improves how emacs describe the mode (`C-h m`)