### PR TITLE
fix versuri-search behavior

### DIFF
--- a/versuri.el
+++ b/versuri.el
@@ -170,9 +170,7 @@ the STR matches multiple lines in the lyrics."
          (song (when res
                  (completing-read "Select Lyrics: " res))))
     (when song
-      (let ((s (assoc song res #'string=)))
-        (versuri-display (cadr s)
-                         (caddr s))))))
+      (cdr (assoc song res #'string=)))))
 
 (defalias 'versuri-ivy-search #'versuri-search)
 


### PR DESCRIPTION
with #6 I mistakenly changed the behavior of versuri-search to call
versuri-display on the selection instead of simply returning the list
of author and song title.

This reverts to the correct behavior.