### PR TITLE
add faces

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ will be implemented.
 
     Major mode for versuri lyrics buffers.
 
+**versuri-lyrics-title-face** and **versuri-lyrics-text-face**
+
+    Faces used in the versuri buffers for the lyric title and text.
+
 **versuri-display** (artist song)
 
     Search and display the lyrics for ARTIST and SONG in a buffer.

--- a/versuri.el
+++ b/versuri.el
@@ -352,6 +352,14 @@ incomplete, some might be ugly."
   (kill-buffer versuri--buffer)
   (versuri-display versuri--artist versuri--song))
 
+(defface versuri-lyrics-title
+  '((t :inherit default :height 1.6))
+  "Face for the lyrics title in `versuri-mode'.")
+
+(defface versuri-lyrics-text
+  '((t :inherit default))
+  "Face for the lyrics text in `versuri-mode'.")
+
 (defvar versuri-mode-map
   (let ((m (make-sparse-keymap)))
     (define-key m (kbd "q") #'kill-current-buffer)
@@ -381,8 +389,12 @@ already exists, switch to it and don't create a new buffer."
           (let ((b (generate-new-buffer name)))
             (with-current-buffer b
               (save-excursion
-                (insert (format "%s - %s\n\n" artist song))
-                (insert lyrics))
+                (insert
+                 (propertize (format "%s - %s\n\n" artist song)
+                             'face 'versuri-lyrics-title))
+                (insert
+                 (propertize lyrics
+                             'face 'versuri-lyrics-text)))
               (versuri-mode)
               (setq-local versuri--artist artist)
               (setq-local versuri--song song)


### PR DESCRIPTION
Hello,

I thought that a bigger font for the title wouldn't look bad :)

![20211104113950](https://user-images.githubusercontent.com/47739920/140300880-c8e1a06a-c0bc-43af-9d93-0e74fa1102e8.png)

The idea is to provide custom faces so users (and theme makers) can style the versuri buffer.  I've added two faces: one for the title and one for the text.

The default `:height 1.6` in the `versuri-lyrics-title-face` could be probably dropped if you don't like it.