### PR TITLE
Allow editing an existing lyric

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ will be implemented.
 
     Major mode for versuri lyrics buffers.
 
+**versuri-edit-mode**
+
+    Major mode for editing lyrics.
+
 **versuri-lyrics-title-face** and **versuri-lyrics-text-face**
 
     Faces used in the versuri buffers for the lyric title and text.

--- a/versuri.el
+++ b/versuri.el
@@ -118,6 +118,15 @@ Set ARTIST to NEW-ARTIST and SONG to NEW-SONG."
            (esqlite-escape-string artist ?\")
            (esqlite-escape-string song ?\"))))
 
+(defun versuri--db-update-lyric (artist song lyric)
+  "Update the LYRIC for ARTIST and SONG in the database."
+  (esqlite-stream-execute
+   (versuri--db-stream)
+   (format "UPDATE lyrics set lyrics = \"%s\" where artist = \"%s\" and song = \"%s\""
+           (esqlite-escape-string (s-trim lyric) ?\")
+           (esqlite-escape-string artist ?\")
+           (esqlite-escape-string song ?\"))))
+
 (defun versuri-delete-lyrics (artist song)
   "Remove entry for ARTIST and SONG form the database."
   (print (format "%s - %s" artist song))
@@ -463,8 +472,7 @@ the db."
                  (widen)
                  (buffer-substring-no-properties (point-min)
                                                  (point-max)))))
-    (versuri-delete-lyrics versuri--artist versuri--song)
-    (versuri--db-save-lyrics versuri--artist versuri--song lyric)
+    (versuri--db-update-lyric versuri--artist versuri--song lyric)
     ;; update the lyric in the original buffer
     (when versuri--buffer
       (with-current-buffer versuri--buffer

--- a/versuri.el
+++ b/versuri.el
@@ -377,6 +377,7 @@ incomplete, some might be ugly."
     ;; don't allow undoing the initial buffer insertion
     (buffer-disable-undo)
     (insert lyric)
+    (set-buffer-modified-p nil)
     (goto-char (point-min))
     (buffer-enable-undo)
     (versuri-edit-mode)

--- a/versuri.el
+++ b/versuri.el
@@ -383,7 +383,10 @@ incomplete, some might be ugly."
     (setq-local versuri--artist artist)
     (setq-local versuri--song song)
     (setq-local versuri--buffer lyric-buffer)
-    (add-hook 'after-save-hook #'versuri-save-lyric nil t)))
+    (add-hook 'after-save-hook #'versuri-save-lyric nil t)
+    (add-hook 'kill-buffer-hook (lambda ()
+                                  (delete-file buffer-file-name))
+              nil t)))
 
 (defface versuri-lyrics-title
   '((t :inherit default :height 1.6))

--- a/versuri.el
+++ b/versuri.el
@@ -398,7 +398,7 @@ already exists, switch to it and don't create a new buffer."
               (versuri-mode)
               (setq-local versuri--artist artist)
               (setq-local versuri--song song)
-              (setq-local versuri--buffer it))
+              (setq-local versuri--buffer b))
             (switch-to-buffer b)))))))
 
 (defun versuri-save (artist song)


### PR DESCRIPTION
From time to time, I'd like to tweak the lyrics fetched from versuri.  Maybe it's just a wrong line break, or a typo, or a strange quoting, something like that.

This PR adds a `versuri-lyric-edit` command that pops a buffer in `text-mode` where the user can edit the existing buffer.  Even better: after save the lyric buffer gets automatically updated :D

It's still a draft, I just noticed that the temporary file used to store the lyric remains and clutters the /tmp.

I'd also like to add a `versuri-add-lyric` command to manually insert a lyric for those cases where versuri fails to fetch one.  (use case: I don't seem to be able to fetch the lyric for "It's the end of the world as we know it (and I feel fine)", but still like to be able to read it using versuri)

Cheers