### PR TITLE
Use sync esqlite api instead of stream api to support MacOS

### DIFF
--- a/versuri.el
+++ b/versuri.el
@@ -50,12 +50,12 @@
 (defconst versuri--db-file-name "/versuri.db"
   "Name of the db containing all the lyrics.")
 
-(defconst versuri--db-process nil
-  "The process containing the opened db stream.")
+(defconst versuri--db-file nil
+  "The path to the db.")
 
-(defun versuri--db-stream ()
-  "Return the db stream or create and open it if doesn't exist."
-  (unless versuri--db-process
+(defun versuri--db-file ()
+  "Return the db file or create it if doesn't exist."
+  (unless versuri--db-file
     (let ((db-path (concat (xdg-config-home)
                            versuri--db-file-name)))
       (esqlite-execute db-path
@@ -68,13 +68,12 @@
                 "song   TEXT    NOT NULL "
                 "               COLLATE NOCASE, "
                 "lyrics TEXT    COLLATE NOCASE);"))
-      (setf versuri--db-process
-            (esqlite-stream-open db-path))))
-  versuri--db-process)
+      (setf versuri--db-file db-path)))
+  versuri--db-file)
 
 (defun versuri--db-read (query)
   "Call the QUERY on the database and return the result."
-  (esqlite-stream-read (versuri--db-stream) query))
+  (esqlite-read (versuri--db-file) query))
 
 (defun versuri--db-get-lyrics (artist song)
   "Retrieve the stored lyrics for ARTIST and SONG."
@@ -101,7 +100,7 @@
 
 (defun versuri--db-save-lyrics (artist song lyrics)
   "Save the LYRICS for ARTIST and SONG in the database."
-  (esqlite-stream-execute (versuri--db-stream)
+  (esqlite-execute (versuri--db-file)
    (format "INSERT INTO lyrics(artist,song,lyrics) VALUES(\"%s\", \"%s\", \"%s\")"
            (esqlite-escape-string artist ?\")
            (esqlite-escape-string song ?\")
@@ -110,8 +109,8 @@
 (defun versuri-delete-lyrics (artist song)
   "Remove entry for ARTIST and SONG form the database."
   (print (format "%s - %s" artist song))
-  (esqlite-stream-execute
-   (versuri--db-stream)
+  (esqlite-execute
+   (versuri--db-file)
    (format "DELETE FROM lyrics WHERE artist=\"%s\" and song=\"%s\""
            artist song)))
 


### PR DESCRIPTION
Esqlite author stated[1] that stream functions does not work well with
MacOS. So I simply replaced those functions with their non-stream
counterparts.

This theoretically makes versuri a bit slower (because it spawns a new
process every time it does a request to DB instead of talking with an
already spawned process) but (at least for my use case) I haven't
experienced any noticeable slowdown. This probably effects the bulk
operations most but I don't use them. Feedback is appreciated on this.

Fixes #3 

[1]: https://github.com/mhayashi1120/Emacs-esqlite/issues/2#issuecomment-36472535
